### PR TITLE
Match _Unwind_Reason_Code enum between ARM and Itanium.

### DIFF
--- a/src/unwind-arm.h
+++ b/src/unwind-arm.h
@@ -29,6 +29,7 @@
  */
  typedef enum
 {
+	_URC_NO_REASON = 0,
 	_URC_OK = 0,                /* operation completed successfully */
 	_URC_FOREIGN_EXCEPTION_CAUGHT = 1,
 	_URC_END_OF_STACK = 5,

--- a/src/unwind-itanium.h
+++ b/src/unwind-itanium.h
@@ -40,6 +40,7 @@ extern "C" {
 typedef enum
   {
     _URC_NO_REASON = 0,
+    _URC_OK = 0,
     _URC_FOREIGN_EXCEPTION_CAUGHT = 1,
     _URC_FATAL_PHASE2_ERROR = 2,
     _URC_FATAL_PHASE1_ERROR = 3,


### PR DESCRIPTION
Unwind ARM was using `_URC_OK` and Itanium `_URC_NO_REASON`, which made it difficult to write code that worked with both versions. This adds the missing one to each, which matches what is done in libunwind:
https://github.com/llvm/llvm-project/blob/master/libunwind/include/unwind.h#L33-L34