### PR TITLE
Mostly fix __cxa_demangle after #3

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,54 +4,78 @@ set(CXXTEST_SOURCES
     test_exception.cc
     test_guard.cc
     test_typeinfo.cc
+    test_demangle.cc
    )
 
 
-add_executable(system-test ${CXXTEST_SOURCES})
+option(COMPARE_TEST_OUTPUT_TO_SYSTEM_OUTPUT "Compare tests with system output" ON)
+if(COMPARE_TEST_OUTPUT_TO_SYSTEM_OUTPUT)
+    add_executable(system-test ${CXXTEST_SOURCES})
 
-# Generating excpected output with system-test
-add_custom_target(test-expected-output ALL
-                  COMMAND system-test > ${CMAKE_CURRENT_BINARY_DIR}/expected_output.log 2>&1
-                  DEPENDS system-test)
+    # Generating excpected output with system-test
+    add_custom_target(test-expected-output ALL
+                      COMMAND system-test > ${CMAKE_CURRENT_BINARY_DIR}/expected_output.log 2>&1
+                      DEPENDS system-test)
+    set(HAVE_EXPECTED_OUTPUT TRUE)
+else()
+    set(HAVE_EXPECTED_OUTPUT FALSE)
+endif()
 
+set(NO_STATIC_TEST_DEFAULT OFF)
+option(NO_STATIC_TEST "Don't build the static test" ${NO_STATIC_TEST_DEFAULT})
+set(STATIC_LIB_DEPS gcc_eh)
+find_library(LIBCOMPILER_RT_STATIC libcompiler_rt.a)
+find_library(LIBGCC_STATIC libgcc.a)
+if(LIBCOMPILER_RT_STATIC)
+    list(APPEND STATIC_LIB_DEPS ${LIBCOMPILER_RT_STATIC})
+elseif(LIBGCC_STATIC)
+    list(APPEND STATIC_LIB_DEPS ${LIBGCC_STATIC})
+else()
+    message(STATUS "Could not find libgcc.a or libcompiler_rt.a, not building static tests")
+    set(NO_STATIC_TEST TRUE)
+endif()
+message(STATUS "static lib deps: ${STATIC_LIB_DEPS}")
 
-add_executable(cxxrt-test-static ${CXXTEST_SOURCES})
-set_property(TARGET cxxrt-test-static PROPERTY LINK_FLAGS -nodefaultlibs)
-target_link_libraries(cxxrt-test-static cxxrt-static gcc_s pthread ${CMAKE_DL_LIBS} c)
+if(NOT NO_STATIC_TEST)
+    add_executable(cxxrt-test-static ${CXXTEST_SOURCES})
+    set_property(TARGET cxxrt-test-static PROPERTY LINK_FLAGS "-nodefaultlibs -static")
+    target_link_libraries(cxxrt-test-static cxxrt-static pthread ${CMAKE_DL_LIBS} c ${STATIC_LIB_DEPS})
+    add_test(cxxrt-test-static-test
+             ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
+             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-static
+             ${CMAKE_CURRENT_BINARY_DIR}/expected_output.log
+             ${CMAKE_CURRENT_BINARY_DIR}/test-static-output.log)
+endif()
 
 add_executable(cxxrt-test-shared ${CXXTEST_SOURCES})
 set_property(TARGET cxxrt-test-shared PROPERTY LINK_FLAGS -nodefaultlibs)
 target_link_libraries(cxxrt-test-shared cxxrt-shared pthread ${CMAKE_DL_LIBS} c)
-
-include_directories(${CMAKE_SOURCE_DIR}/src)
-add_executable(cxxrt-test-foreign-exceptions test_foreign_exceptions.cc)
-set_property(TARGET cxxrt-test-foreign-exceptions PROPERTY LINK_FLAGS "-nodefaultlibs -Wl,--wrap,_Unwind_RaiseException")
-target_link_libraries(cxxrt-test-foreign-exceptions cxxrt-static gcc_s pthread ${CMAKE_DL_LIBS} c)
-
-add_test(cxxrt-test-static-test
-         ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
-         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-static
-         ${CMAKE_CURRENT_BINARY_DIR}/expected_output.log
-         ${CMAKE_CURRENT_BINARY_DIR}/test-static-output.log)
-
 add_test(cxxrt-test-shared-test
          ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-shared
          ${CMAKE_CURRENT_BINARY_DIR}/expected_output.log
          ${CMAKE_CURRENT_BINARY_DIR}/test-shared-output.log)
 
-add_test(cxxrt-test-foreign-exceptions
-         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-foreign-exceptions)
+include_directories(${CMAKE_SOURCE_DIR}/src)
+if(NOT APPLE)
+    # No --wrap option for the macOS ld
+    add_executable(cxxrt-test-foreign-exceptions test_foreign_exceptions.cc)
+    set_property(TARGET cxxrt-test-foreign-exceptions PROPERTY LINK_FLAGS "-nodefaultlibs -Wl,--wrap,_Unwind_RaiseException")
+    target_link_libraries(cxxrt-test-foreign-exceptions cxxrt-static gcc_s pthread ${CMAKE_DL_LIBS} c)
+    add_test(cxxrt-test-foreign-exceptions
+             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-foreign-exceptions)
+endif()
 
 set(valgrind "valgrind -q")
 
 if(TEST_VALGRIND)
-    add_test(cxxrt-test-static-test-valgrind
-             ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
-             "${valgrind} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-static"
-             ${CMAKE_CURRENT_BINARY_DIR}/expected_output.log
-             ${CMAKE_CURRENT_BINARY_DIR}/test-static-output.log)
-    
+    if (NOT NO_STATIC_TEST)
+        add_test(cxxrt-test-static-test-valgrind
+                 ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
+                 "${valgrind} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-static"
+                 ${CMAKE_CURRENT_BINARY_DIR}/expected_output.log
+                 ${CMAKE_CURRENT_BINARY_DIR}/test-static-output.log)
+    endif()
     add_test(cxxrt-test-shared-test-valgrind
              ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
              "${valgrind} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-shared"
@@ -68,12 +92,13 @@ if(TEST_LIBUNWIND)
         message(FATAL_ERROR "Path to libunwind should be specified. Please set LIBUNWIND_PATH variable")
     endif()
 
-    add_executable(cxxrt-test-libunwind-static ${CXXTEST_SOURCES})
-    set_property(TARGET cxxrt-test-libunwind-static PROPERTY LINK_FLAGS
-                 "-L${LIBUNWIND_PATH} -nodefaultlibs")
-    target_link_libraries(cxxrt-test-libunwind-static cxxrt-static
-                          ${LIBUNWIND_PATH}/libunwind.a pthread gcc ${CMAKE_DL_LIBS} c)
-
+    if (NOT NO_STATIC_TEST)
+        add_executable(cxxrt-test-libunwind-static ${CXXTEST_SOURCES})
+        set_property(TARGET cxxrt-test-libunwind-static PROPERTY LINK_FLAGS
+                     "-L${LIBUNWIND_PATH} -nodefaultlibs")
+        target_link_libraries(cxxrt-test-libunwind-static cxxrt-static
+                              ${LIBUNWIND_PATH}/libunwind.a pthread ${CMAKE_DL_LIBS} c ${STATIC_LIB_DEPS})
+    endif()
     add_test(cxxrt-test-libunwind-static-test
              ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
              ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-libunwind-static
@@ -93,11 +118,13 @@ if(TEST_LIBUNWIND)
              ${CMAKE_CURRENT_BINARY_DIR}/test-libunwind-shared-output.log)
 
     if(TEST_VALGRIND)
-        add_test(cxxrt-test-libunwind-static-test-valgrind
-                 ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
-                 "${valgrind} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-libunwind-static"
-                 ${CMAKE_CURRENT_BINARY_DIR}/expected_output.log
-                 ${CMAKE_CURRENT_BINARY_DIR}/test-libunwind-static-output.log)
+        if (NOT NO_STATIC_TEST)
+            add_test(cxxrt-test-libunwind-static-test-valgrind
+                     ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh
+                     "${valgrind} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cxxrt-test-libunwind-static"
+                     ${CMAKE_CURRENT_BINARY_DIR}/expected_output.log
+                     ${CMAKE_CURRENT_BINARY_DIR}/test-libunwind-static-output.log)
+         endif()
 
         add_test(cxxrt-test-libunwind-shared-test-valgrind
                  ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh

--- a/test/test.cc
+++ b/test/test.cc
@@ -35,6 +35,7 @@ static void __attribute__((constructor)) init(void)
 void test_type_info(void);
 void test_exceptions();
 void test_guards(void);
+void test_demangle(void);
 int main(int argc, char **argv)
 {
 	int ch;
@@ -52,5 +53,6 @@ int main(int argc, char **argv)
 	test_type_info();
 	test_guards();
 	test_exceptions();
+	test_demangle();
 	return 0;
 }

--- a/test/test.h
+++ b/test/test.h
@@ -2,3 +2,4 @@
 void log_test(bool predicate, const char *file, int line, const char *message);
 
 #define TEST(p, m) log_test(p, __FILE__, __LINE__, m)
+#define TEST_LOC(p, m, file, line) log_test(p, file, line, m)

--- a/test/test_demangle.cc
+++ b/test/test_demangle.cc
@@ -1,0 +1,45 @@
+#include "test.h"
+#include <cxxabi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <list>
+
+template <typename T> void test(const char* expected, int line) {
+	const char *mangled = typeid(T).name();
+	int status = 0;
+	using abi::__cxa_demangle;
+	char* demangled = __cxa_demangle(mangled, 0, 0, &status);
+	printf("mangled='%s' demangled='%s', status=%d\n", mangled, demangled,
+	    status);
+	free(demangled);
+	TEST_LOC(status == 0, "should be able to demangle", __FILE__, line);
+	TEST_LOC(demangled != 0, "should be able to demangle", __FILE__, line);
+	if (!demangled) {
+		/* Don't dereference NULL in strcmp() */
+		return;
+	}
+	TEST_LOC(strcmp(expected, demangled) == 0, "should be able to demangle",
+	    __FILE__, line);
+	TEST_LOC(strcmp(mangled, demangled) != 0, "should be able to demangle",
+	    __FILE__, line);
+}
+
+
+namespace N {
+template<typename T, int U>
+class Templated {
+	virtual ~Templated() {};
+};
+}
+
+void test_demangle(void)
+{
+	using namespace N;
+	test<int>("int", __LINE__);
+	test<char[4]>("char [4]", __LINE__);
+	test<Templated<Templated<long, 7>, 8> >(
+	    "N::Templated<N::Templated<long, 7>, 8>", __LINE__);
+	test<Templated<void(long), -1> >(
+	    "N::Templated<void (long), -1>", __LINE__);
+}

--- a/test/test_exception.cc
+++ b/test/test_exception.cc
@@ -8,12 +8,12 @@
 
 #define fprintf(...)
 
-void log(void* ignored)
+void log_cleanup(void* ignored)
 {
 	//printf("Cleanup called on %s\n", *(char**)ignored);
 }
 #define CLEANUP\
-	__attribute__((cleanup(log))) __attribute__((unused))\
+	__attribute__((cleanup(log_cleanup))) __attribute__((unused))\
 		const char *f = __func__;
 
 /**


### PR DESCRIPTION
After updating the elftoolchain demangler, types were no longer
being demangled. This breaks demangling e.g. typeid(T).name().

To fix this re-apply the changes from 18482f1
that were lost when merging #3.
We still don't demangle array types, but that can be addressed in a
follow-up change

Mostly fixes #5