### PR TITLE
Match libc++abi/libsupc++ when demangling array types

### DIFF
--- a/src/libelftc_dem_gnu3.c
+++ b/src/libelftc_dem_gnu3.c
@@ -1120,7 +1120,7 @@ cpp_demangle_read_array(struct cpp_demangle_data *ddata)
 		if (!cpp_demangle_read_type(ddata, NULL))
 			return (0);
 
-		if (!DEM_PUSH_STR(ddata, "[]"))
+		if (!DEM_PUSH_STR(ddata, " []"))
 			return (0);
 	} else {
 		if (ELFTC_ISDIGIT(*ddata->cur) != 0) {
@@ -1135,7 +1135,7 @@ cpp_demangle_read_array(struct cpp_demangle_data *ddata)
 				return (0);
 			if (!cpp_demangle_read_type(ddata, NULL))
 				return (0);
-			if (!DEM_PUSH_STR(ddata, "["))
+			if (!DEM_PUSH_STR(ddata, " ["))
 				return (0);
 			if (!cpp_demangle_push_str(ddata, num, num_len))
 				return (0);
@@ -1167,7 +1167,7 @@ cpp_demangle_read_array(struct cpp_demangle_data *ddata)
 				free(exp);
 				return (0);
 			}
-			if (!DEM_PUSH_STR(ddata, "[")) {
+			if (!DEM_PUSH_STR(ddata, " [")) {
 				free(exp);
 				return (0);
 			}

--- a/test/test_demangle.cc
+++ b/test/test_demangle.cc
@@ -38,6 +38,7 @@ void test_demangle(void)
 	using namespace N;
 	test<int>("int", __LINE__);
 	test<char[4]>("char [4]", __LINE__);
+	test<char[]>("char []", __LINE__);
 	test<Templated<Templated<long, 7>, 8> >(
 	    "N::Templated<N::Templated<long, 7>, 8>", __LINE__);
 	test<Templated<void(long), -1> >(


### PR DESCRIPTION
Both of these libraries include a space between the type and the "[".
Patch also submitted upstream as https://sourceforge.net/p/elftoolchain/tickets/602/

Actually fixes #5 (all tests pass now).