### PR TITLE
Fix unitialized variable in __cxa_demangle_gnu3 after #6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
+project(libcxxrt)
 
 enable_testing()
 

--- a/src/libelftc_dem_gnu3.c
+++ b/src/libelftc_dem_gnu3.c
@@ -538,14 +538,13 @@ __cxa_demangle_gnu3(const char *org)
 	struct type_delimit td;
 	ssize_t org_len;
 	unsigned int limit;
-	char *rtn;
-	bool has_ret, more_type;
+	char *rtn = NULL;
+	bool has_ret = false, more_type = false;
 
 	if (org == NULL)
 		return (NULL);
 
 	org_len = strlen(org);
-	rtn = NULL;
 	// Try demangling as a type for short encodings
 	if ((org_len < 2) || (org[0] != '_' || org[1] != 'Z' )) {
 		if (!cpp_demangle_data_init(&ddata, org))
@@ -563,11 +562,8 @@ __cxa_demangle_gnu3(const char *org)
 		return (rtn);
 	}
 
-
 	if (!cpp_demangle_data_init(&ddata, org + 2))
 		return (NULL);
-
-	has_ret = more_type = false;
 
 	if (!cpp_demangle_read_encoding(&ddata))
 		goto clean;

--- a/src/libelftc_dem_gnu3.c
+++ b/src/libelftc_dem_gnu3.c
@@ -545,6 +545,7 @@ __cxa_demangle_gnu3(const char *org)
 		return (NULL);
 
 	org_len = strlen(org);
+	rtn = NULL;
 	// Try demangling as a type for short encodings
 	if ((org_len < 2) || (org[0] != '_' || org[1] != 'Z' )) {
 		if (!cpp_demangle_data_init(&ddata, org))
@@ -566,7 +567,6 @@ __cxa_demangle_gnu3(const char *org)
 	if (!cpp_demangle_data_init(&ddata, org + 2))
 		return (NULL);
 
-	rtn = NULL;
 	has_ret = more_type = false;
 
 	if (!cpp_demangle_read_encoding(&ddata))


### PR DESCRIPTION
After #6, if the path "Try demangling as a type for short encodings" is entered, and `cpp_demangle_read_type()` fails, `rtn` is uninitialized but still returned after jumping to the `clean` label. The returned garbage causes problems when `__cxa_demangle()` then supposes the result is valid, and tries to `free()` it later.

On FreeBSD this showed up as a CI failure in googletest's gmock-matchers test, which started aborting on the bad `free()`:

```
<jemalloc>: jemalloc_rtree.c:205: Failed assertion: "!dependent || leaf != NULL"
Process with PID 42015 exited with signal 6 and dumped core; attempting to gather stack trace
```

In this case, it is attempting to demangle `NSt3__15tupleIJibEEE`, and apparenty this is a "naked" variant of `std::__1::tuple<int, bool>` so it fails.
