### PR TITLE
Added stubs required by libcxx when built without exception support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
             name: "macOS Release",
             os: "macos-latest",
             build-type: Release,
-            dependencies: "brew update && brew install cmake ninja"
+            dependencies: "rm -f /usr/local/bin/2to3 ; brew update && brew install cmake ninja"
           }
         - {
             name: "Ubuntu Debug",
@@ -60,7 +60,7 @@ jobs:
             name: "macOS Debug",
             os: "macos-latest",
             build-type: Debug,
-            dependencies: "brew update && brew install cmake ninja"
+            dependencies: "rm -f /usr/local/bin/2to3 ; brew update && brew install cmake ninja"
           }
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
             name: "macOS Release",
             os: "macos-latest",
             build-type: Release,
-            dependencies: "rm '/usr/local/bin/2to3' && brew update && brew install cmake ninja"
+            dependencies: "brew update && brew install cmake ninja"
           }
         - {
             name: "Ubuntu Debug",
@@ -60,7 +60,7 @@ jobs:
             name: "macOS Debug",
             os: "macos-latest",
             build-type: Debug,
-            dependencies: "rm '/usr/local/bin/2to3' && brew update && brew install cmake ninja"
+            dependencies: "brew update && brew install cmake ninja"
           }
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
             name: "macOS Release",
             os: "macos-latest",
             build-type: Release,
-            dependencies: "brew update && brew install cmake ninja"
+            dependencies: "brew unlink python && brew update && brew install cmake ninja"
           }
         - {
             name: "Ubuntu Debug",
@@ -60,7 +60,7 @@ jobs:
             name: "macOS Debug",
             os: "macos-latest",
             build-type: Debug,
-            dependencies: "brew update && brew install cmake ninja"
+            dependencies: "brew unlink python && brew update && brew install cmake ninja"
           }
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
             name: "macOS Release",
             os: "macos-latest",
             build-type: Release,
-            dependencies: "brew unlink python && brew update && brew install cmake ninja"
+            dependencies: "rm '/usr/local/bin/2to3' && brew update && brew install cmake ninja"
           }
         - {
             name: "Ubuntu Debug",
@@ -60,7 +60,7 @@ jobs:
             name: "macOS Debug",
             os: "macos-latest",
             build-type: Debug,
-            dependencies: "brew unlink python && brew update && brew install cmake ninja"
+            dependencies: "rm '/usr/local/bin/2to3' && brew update && brew install cmake ninja"
           }
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.name }}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(CXXRT_SOURCES
     dynamic_cast.cc
     guard.cc
+    stdexcept.cc
     typeinfo.cc
     memory.cc
     auxhelper.cc
@@ -12,7 +13,11 @@ if (NOT CXXRT_NO_EXCEPTIONS)
 set(CXXRT_SOURCES
     ${CXXRT_SOURCES}
     exception.cc
-    stdexcept.cc
+   )
+else()
+set(CXXRT_SOURCES
+    ${CXXRT_SOURCES}
+    noexception.cc
    )
 endif()
 

--- a/src/noexception.cc
+++ b/src/noexception.cc
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2010-2011 PathScale, Inc. All rights reserved.
+ * Copyright 2021 Microsoft. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -24,53 +24,11 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdlib.h>
-
 namespace std
 {
-	// Forward declaration of standard library terminate() function used to
-	// abort execution.
-	void terminate(void);
-}
-
-extern "C" void __cxa_rethrow_primary_exception(void* thrown_exception)
-{
-	if (NULL == thrown_exception) { return; }
-
-	std::terminate();
-}
-
-extern "C" void *__cxa_current_primary_exception(void)
-{
-	return NULL;
-}
-
-extern "C" void __cxa_increment_exception_refcount(void* thrown_exception)
-{
-	if (NULL == thrown_exception) { return; }
-
-	std::terminate();
-}
-
-extern "C" void __cxa_decrement_exception_refcount(void* thrown_exception)
-{
-	if (NULL == thrown_exception) { return; }
-
-	std::terminate();
-}
-
-namespace std
-{
-	/**
-	 * Terminates the program.
-	 */
-	void terminate()
-	{
-		abort();
-	}
 	/**
 	 * Returns whether there are any exceptions currently being thrown that
-	 * have not been caught.  This can occur inside a nested catch statement.
+	 * have not been caught. Without exception support this is always false.
 	 */
 	bool uncaught_exception() throw()
 	{
@@ -78,7 +36,7 @@ namespace std
 	}
 	/**
 	 * Returns the number of exceptions currently being thrown that have not
-	 * been caught.  This can occur inside a nested catch statement.
+	 * been caught. Without exception support this is always 0.
 	 */
 	int uncaught_exceptions() throw()
 	{

--- a/src/noexception.cc
+++ b/src/noexception.cc
@@ -1,0 +1,87 @@
+/* 
+ * Copyright 2010-2011 PathScale, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS
+ * IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+
+namespace std
+{
+	// Forward declaration of standard library terminate() function used to
+	// abort execution.
+	void terminate(void);
+}
+
+extern "C" void __cxa_rethrow_primary_exception(void* thrown_exception)
+{
+	if (NULL == thrown_exception) { return; }
+
+  std::terminate();
+}
+
+extern "C" void *__cxa_current_primary_exception(void)
+{
+	return NULL;
+}
+
+extern "C" void __cxa_increment_exception_refcount(void* thrown_exception)
+{
+	if (NULL == thrown_exception) { return; }
+
+  std::terminate();
+}
+
+extern "C" void __cxa_decrement_exception_refcount(void* thrown_exception)
+{
+	if (NULL == thrown_exception) { return; }
+
+  std::terminate();
+}
+
+namespace std
+{
+  /**
+	 * Terminates the program.
+	 */
+	void terminate()
+	{
+		abort();
+	}
+	/**
+	 * Returns whether there are any exceptions currently being thrown that
+	 * have not been caught.  This can occur inside a nested catch statement.
+	 */
+	bool uncaught_exception() throw()
+	{
+		return false;
+	}
+	/**
+	 * Returns the number of exceptions currently being thrown that have not
+	 * been caught.  This can occur inside a nested catch statement.
+	 */
+	int uncaught_exceptions() throw()
+	{
+		return 0;
+	}
+}

--- a/src/noexception.cc
+++ b/src/noexception.cc
@@ -37,7 +37,7 @@ extern "C" void __cxa_rethrow_primary_exception(void* thrown_exception)
 {
 	if (NULL == thrown_exception) { return; }
 
-  std::terminate();
+	std::terminate();
 }
 
 extern "C" void *__cxa_current_primary_exception(void)
@@ -49,19 +49,19 @@ extern "C" void __cxa_increment_exception_refcount(void* thrown_exception)
 {
 	if (NULL == thrown_exception) { return; }
 
-  std::terminate();
+	std::terminate();
 }
 
 extern "C" void __cxa_decrement_exception_refcount(void* thrown_exception)
 {
 	if (NULL == thrown_exception) { return; }
 
-  std::terminate();
+	std::terminate();
 }
 
 namespace std
 {
-  /**
+	/**
 	 * Terminates the program.
 	 */
 	void terminate()


### PR DESCRIPTION
The initial version of the no-exception variant was suitable for standalone work, but libcxx expects a small number of stubs to be implemented regarding exceptions.
This PR adds a noexception.cc file which is analogous to exception.cc, but implementing only the required stubs.
This file could support the termination handler functionality, but I skipped it to not generate too much code duplication. Let me know if you would like me to bring that functionality over.