### PR TITLE
Add an option for disabling emergency buffers.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         build-type: [ Debug, Release ]
-    runs-on: macos-latest
+    runs-on: macos-10.15
     name: Test in FreeBSD
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Test in FreeBSD
       id: test
-      uses: vmactions/freebsd-vm@v0.1.5
+      uses: vmactions/freebsd-vm@v0.1.6
       with:
         usesh: true
         prepare: pkg install -y cmake ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ set(CMAKE_CXX_STANDARD 11)
 
 enable_testing()
 
+option(LIBCXXRT_NO_EMERGENCY_BUFFERS
+       "Disable emergency buffers when allocation fails throwing an exception (see section 3.3.1 of the Itanium ABI specification)"
+       OFF)
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
@@ -13,6 +17,8 @@ if (CXXRT_NO_EXCEPTIONS)
     add_definitions(-D_CXXRT_NO_EXCEPTIONS)
     add_compile_options(-fno-exceptions)
 endif()
+
+add_compile_definitions($<$<BOOL:${LIBCXXRT_NO_EMERGENCY_BUFFERS}>:LIBCXXRT_NO_EMERGENCY_MALLOC>)
 
 add_subdirectory(src)
 IF(BUILD_TESTS)


### PR DESCRIPTION
Section 3.3.1 of the Itanium ABI spec requires that we provide a small
set of emergency buffers to use when dynamic allocation of shared
objects fails.  We implement these because the spec says so but they
introduce a dependency on condition variables (which is not ideal on all
platforms) and they increase the binary size for negligible real-world
benefit (on systems with overcommit, allocation will succeed bug
accessing the page will fail and very few C++ codebases even attempt to
catch out-of-memory exceptions).

It is now possible to disable these buffers.  This option is off by
default, since the spec requires it.