### PR TITLE
Insert padding in __cxa_exception struct for compatibility

### DIFF
--- a/src/cxxabi.h
+++ b/src/cxxabi.h
@@ -78,6 +78,13 @@ struct __cxa_exception
 {
 #if __LP64__
 	/**
+	 * Now _Unwind_Exception is marked with __attribute__((aligned)), which
+	 * implies __cxa_exception is also aligned.  Insert padding in the
+	 * beginning of the struct, rather than before unwindHeader.
+	 */
+	void *reserve;
+
+	/**
 	 * Reference count.  Used to support the C++11 exception_ptr class.  This
 	 * is prepended to the structure in 64-bit mode and squeezed in to the
 	 * padding left before the 64-bit aligned _Unwind_Exception at the end in


### PR DESCRIPTION
Similar to https://github.com/llvm/llvm-project/commit/f2a436058fcb, the
addition of __attribute__((__aligned__)) to _Unwind_Exception (in commit
b9616964) causes implicit padding to be inserted before the unwindHeader
field in __cxa_exception.

Applications attempt to get at the earlier fields in __cxa_exception, so
preserve the same negative offsets in __cxa_exception, by moving the
padding to the beginning of the struct.

The assumption here is that if the ABI is not aware of the padding
before unwindHeader and put the referenceCount/primaryException in
there, no padding should exist before unwindHeader.
