### PR TITLE
mark __cxa_allocate_exception, __cxa_free_exception and __cxa_init_primary_exception noexcept

### DIFF
--- a/src/cxxabi.h
+++ b/src/cxxabi.h
@@ -204,12 +204,12 @@ __cxa_eh_globals *__cxa_get_globals_fast(void);
 std::type_info * __cxa_current_exception_type();
 
 
-void *__cxa_allocate_exception(size_t thrown_size);
+void *__cxa_allocate_exception(size_t thrown_size) throw();
 
-void __cxa_free_exception(void* thrown_exception);
+void __cxa_free_exception(void* thrown_exception) throw();
 
 __cxa_exception *__cxa_init_primary_exception(
-		void *object, std::type_info* tinfo, void (*dest)(void *));
+		void *object, std::type_info* tinfo, void (*dest)(void *)) throw();
 
 /**
  * Throws an exception returned by __cxa_current_primary_exception().  This

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -121,7 +121,7 @@ static inline _Unwind_Reason_Code continueUnwinding(struct _Unwind_Exception *ex
 }
 
 
-extern "C" void __cxa_free_exception(void *thrown_exception);
+extern "C" void __cxa_free_exception(void *thrown_exception) throw();
 extern "C" void __cxa_free_dependent_exception(void *thrown_exception);
 extern "C" void* __dynamic_cast(const void *sub,
                                 const __class_type_info *src,
@@ -611,7 +611,7 @@ static void free_exception(char *e)
  * emergency buffer if malloc() fails, and may block if there are no such
  * buffers available.
  */
-extern "C" void *__cxa_allocate_exception(size_t thrown_size)
+extern "C" void *__cxa_allocate_exception(size_t thrown_size) throw()
 {
 	size_t size = thrown_size + sizeof(__cxa_exception);
 	char *buffer = alloc_or_die(size);
@@ -633,7 +633,7 @@ extern "C" void *__cxa_allocate_dependent_exception(void)
  * In this implementation, it is also called by __cxa_end_catch() and during
  * thread cleanup.
  */
-extern "C" void __cxa_free_exception(void *thrown_exception)
+extern "C" void __cxa_free_exception(void *thrown_exception) throw()
 {
 	__cxa_exception *ex = reinterpret_cast<__cxa_exception*>(thrown_exception) - 1;
 	// Free the object that was thrown, calling its destructor
@@ -792,7 +792,7 @@ static void throw_exception(__cxa_exception *ex)
 }
 
 extern "C" __cxa_exception *__cxa_init_primary_exception(
-		void *object, std::type_info* tinfo, void (*dest)(void *)) {
+		void *object, std::type_info* tinfo, void (*dest)(void *)) throw() {
 	__cxa_exception *ex = reinterpret_cast<__cxa_exception*>(object) - 1;
 
 	ex->referenceCount = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,6 +78,7 @@ endif()
 add_executable(cxxrt-test-shared ${CXXTEST_SOURCES})
 set_property(TARGET cxxrt-test-shared PROPERTY LINK_FLAGS -nodefaultlibs)
 set_property(TARGET cxxrt-test-shared PROPERTY CXX_STANDARD 11)
+target_compile_definitions(cxxrt-test-shared PRIVATE "TEST_INIT_PRIMARY_EXCEPTION")
 target_link_libraries(cxxrt-test-shared cxxrt-shared pthread ${CMAKE_DL_LIBS} c ${SHARED_LIB_DEPS})
 add_cxxrt_test("cxxrt-test-shared")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ if (NOT CXXRT_NO_EXCEPTIONS)
 set(CXXTEST_SOURCES
     ${CXXTEST_SOURCES}
     test_exception.cc
+    test_init_primary_exception.cc
    )
 endif()
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -34,6 +34,7 @@ static void __attribute__((constructor)) init(void)
 
 void test_type_info(void);
 void test_exceptions();
+void test_init_primary_exception(void);
 void test_guards(void);
 void test_demangle(void);
 int main(int argc, char **argv)
@@ -54,6 +55,7 @@ int main(int argc, char **argv)
 	test_guards();
 #if !defined(_CXXRT_NO_EXCEPTIONS)
 	test_exceptions();
+	test_init_primary_exception();
 #endif
 	test_demangle();
 	return 0;

--- a/test/test.cc
+++ b/test/test.cc
@@ -55,7 +55,9 @@ int main(int argc, char **argv)
 	test_guards();
 #if !defined(_CXXRT_NO_EXCEPTIONS)
 	test_exceptions();
+#ifdef TEST_INIT_PRIMARY_EXCEPTION
 	test_init_primary_exception();
+#endif
 #endif
 	test_demangle();
 	return 0;

--- a/test/test.cc
+++ b/test/test.cc
@@ -55,9 +55,7 @@ int main(int argc, char **argv)
 	test_guards();
 #if !defined(_CXXRT_NO_EXCEPTIONS)
 	test_exceptions();
-#ifdef TEST_INIT_PRIMARY_EXCEPTION
 	test_init_primary_exception();
-#endif
 #endif
 	test_demangle();
 	return 0;

--- a/test/test_exception.cc
+++ b/test/test_exception.cc
@@ -5,8 +5,6 @@
 #include <stdint.h>
 
 #include <exception>
-#include <typeinfo>
-#include <new>
 
 #define fprintf(...)
 
@@ -324,110 +322,6 @@ void test_uncaught_exceptions()
 	catch (...) {}
 }
 
-extern "C"
-{
-	struct __cxa_exception;
-
-	void __cxa_free_exception(void *thrown_exception) throw();
-	void *__cxa_allocate_exception(size_t thrown_size) throw();
-
-	void __cxa_increment_exception_refcount(void* thrown_exception);
-	void __cxa_decrement_exception_refcount(void* thrown_exception);
-
-	__cxa_exception *__cxa_init_primary_exception(
-		void *object, std::type_info* tinfo, void (*dest)(void *));
-
-	void __cxa_rethrow_primary_exception(void* thrown_exception);
-	void *__cxa_current_primary_exception();
-}
-
-class ExceptionPtr final {
-public:
-	ExceptionPtr(void *ex) : ex_(ex) {
-		__cxa_increment_exception_refcount(ex_);
-	}
-	ExceptionPtr(const ExceptionPtr& other) : ex_(other.ex_) {
-		__cxa_increment_exception_refcount(ex_);
-	}
-	~ExceptionPtr() {
-		__cxa_decrement_exception_refcount(ex_);
-	}
-
-private:
-	template <typename Ex>
-	friend ExceptionPtr MakeExceptionPtr(Ex);
-
-	friend void RethrowException(ExceptionPtr);
-
-	template <typename Ex>
-	static void Dest(void *e) {
-		static_cast<Ex*>(e)->~Ex();
-	}
-
-	void *ex_ = nullptr;
-};
-
-template <typename Ex>
-ExceptionPtr MakeExceptionPtr(Ex e) {
-	void *ex = __cxa_allocate_exception(sizeof(Ex));
-	(void)__cxa_init_primary_exception(
-		ex, const_cast<std::type_info*>(&typeid(Ex)), ExceptionPtr::Dest<Ex>);
-	try {
-		new (ex) Ex(e);
-		return ExceptionPtr(ex);
-	} catch (...) {
-		__cxa_free_exception(ex);
-		return ExceptionPtr(__cxa_current_primary_exception());
-	}
-}
-
-void RethrowException(ExceptionPtr eptr) {
-	__cxa_rethrow_primary_exception(eptr.ex_);
-}
-
-struct Base
-{
-	virtual ~Base() {}
-};
-
-static int derived_dtor_count;
-struct Derived final : Base
-{
-	~Derived() override {
-		++derived_dtor_count;
-	}
-};
-
-inline void test_exception_ptr_direct_init()
-{
-	{
-		ExceptionPtr eptr = MakeExceptionPtr(Derived());
-
-		// Argument to MakeExceptionPtr is destroyed
-		if (--derived_dtor_count != 0) {
-			abort();
-		}
-
-		bool exception_caught = false;
-		try {
-			RethrowException(eptr);
-		} catch (const Derived&) {
-			exception_caught = true;
-		} catch (...) {
-		}
-
-		if (!exception_caught) {
-			abort();
-		}
-	}
-
-	// ExceptionPtr went out of scope,
-	// its destructor should've called the exception destructor.
-	if (--derived_dtor_count != 0) {
-		abort();
-	}
-}
-
 extern "C" void __cxa_bad_cast();
 
 void test_exceptions(void)
@@ -478,9 +372,6 @@ void test_exceptions(void)
 	test_rethrown_uncaught_exception();
 	test_rethrown_uncaught_foreign_exception();
 	test_uncaught_exceptions();
-#ifdef TEST_INIT_PRIMARY_EXCEPTION
-	test_exception_ptr_direct_init();
-#endif
 
 
 	//printf("Test: %s\n",

--- a/test/test_init_primary_exception.cc
+++ b/test/test_init_primary_exception.cc
@@ -110,3 +110,4 @@ void test_init_primary_exception(void)
 		abort();
 	}
 }
+

--- a/test/test_init_primary_exception.cc
+++ b/test/test_init_primary_exception.cc
@@ -1,0 +1,112 @@
+#include <typeinfo>
+#include <new>
+#include <stdint.h>
+#include <stdlib.h>
+
+namespace __cxxabiv1 {
+extern "C"
+{
+	struct __cxa_exception;
+
+	void __cxa_free_exception(void *thrown_exception) throw();
+	void *__cxa_allocate_exception(size_t thrown_size) throw();
+
+	void __cxa_increment_exception_refcount(void* thrown_exception);
+	void __cxa_decrement_exception_refcount(void* thrown_exception);
+
+	__cxa_exception *__cxa_init_primary_exception(
+		void *object, std::type_info* tinfo, void (*dest)(void *)) throw();
+
+	void __cxa_rethrow_primary_exception(void* thrown_exception);
+	void *__cxa_current_primary_exception();
+}
+}
+
+using namespace __cxxabiv1;
+
+class ExceptionPtr final {
+public:
+	ExceptionPtr(void *ex) : ex_(ex) {
+		__cxa_increment_exception_refcount(ex_);
+	}
+	ExceptionPtr(const ExceptionPtr& other) : ex_(other.ex_) {
+		__cxa_increment_exception_refcount(ex_);
+	}
+	~ExceptionPtr() {
+		__cxa_decrement_exception_refcount(ex_);
+	}
+
+private:
+	template <typename Ex>
+	friend ExceptionPtr MakeExceptionPtr(Ex);
+
+	friend void RethrowException(ExceptionPtr);
+
+	template <typename Ex>
+	static void Dest(void *e) {
+		static_cast<Ex*>(e)->~Ex();
+	}
+
+	void *ex_ = nullptr;
+};
+
+template <typename Ex>
+ExceptionPtr MakeExceptionPtr(Ex e) {
+	void *ex = __cxa_allocate_exception(sizeof(Ex));
+	(void)__cxa_init_primary_exception(
+		ex, const_cast<std::type_info*>(&typeid(Ex)), ExceptionPtr::Dest<Ex>);
+	try {
+		new (ex) Ex(e);
+		return ExceptionPtr(ex);
+	} catch (...) {
+		__cxa_free_exception(ex);
+		return ExceptionPtr(__cxa_current_primary_exception());
+	}
+}
+
+void RethrowException(ExceptionPtr eptr) {
+	__cxa_rethrow_primary_exception(eptr.ex_);
+}
+
+struct Base
+{
+	virtual ~Base() {}
+};
+
+static int derived_dtor_count;
+struct Derived final : Base
+{
+	~Derived() override {
+		++derived_dtor_count;
+	}
+};
+
+void test_init_primary_exception(void)
+{
+	{
+		ExceptionPtr eptr = MakeExceptionPtr(Derived());
+
+		// Argument to MakeExceptionPtr is destroyed
+		if (--derived_dtor_count != 0) {
+			abort();
+		}
+
+		bool exception_caught = false;
+		try {
+			RethrowException(eptr);
+		} catch (const Derived&) {
+			exception_caught = true;
+		} catch (...) {
+		}
+
+		if (!exception_caught) {
+			abort();
+		}
+	}
+
+	// ExceptionPtr went out of scope,
+	// its destructor should've called the exception destructor.
+	if (--derived_dtor_count != 0) {
+		abort();
+	}
+}

--- a/test/test_init_primary_exception.cc
+++ b/test/test_init_primary_exception.cc
@@ -1,3 +1,5 @@
+#ifdef TEST_INIT_PRIMARY_EXCEPTION
+
 #include <typeinfo>
 #include <new>
 #include <stdint.h>
@@ -110,4 +112,7 @@ void test_init_primary_exception(void)
 		abort();
 	}
 }
+#else
+void test_init_primary_exception(void) {}
+#endif
 


### PR DESCRIPTION
This patch marks `__cxa_allocate_exception`, `__cxa_free_exception` and `__cxa_init_primary_exception` `noexcept` to make these declarations compatible with libsupc++ and libc++abi. 

Aims to resolve https://github.com/libcxxrt/libcxxrt/issues/25