### PR TITLE
Define _LIBCXXRT_NOEXCEPT in cxxabi.h and use it instead of throw()

### DIFF
--- a/src/cxxabi.h
+++ b/src/cxxabi.h
@@ -41,8 +41,15 @@ namespace std
  */
 
 #ifdef __cplusplus
+#if __cplusplus < 201103L
+#define _LIBCXXRT_NOEXCEPT throw()
+#else
+#define _LIBCXXRT_NOEXCEPT noexcept
+#endif
 namespace __cxxabiv1 {
 extern "C" {
+#else
+#define _LIBCXXRT_NOEXCEPT
 #endif
 /**
  * Function type to call when an unexpected exception is encountered.
@@ -204,12 +211,12 @@ __cxa_eh_globals *__cxa_get_globals_fast(void);
 std::type_info * __cxa_current_exception_type();
 
 
-void *__cxa_allocate_exception(size_t thrown_size) throw();
+void *__cxa_allocate_exception(size_t thrown_size) _LIBCXXRT_NOEXCEPT;
 
-void __cxa_free_exception(void* thrown_exception) throw();
+void __cxa_free_exception(void* thrown_exception) _LIBCXXRT_NOEXCEPT;
 
 __cxa_exception *__cxa_init_primary_exception(
-		void *object, std::type_info* tinfo, void (*dest)(void *)) throw();
+		void *object, std::type_info* tinfo, void (*dest)(void *)) _LIBCXXRT_NOEXCEPT;
 
 /**
  * Throws an exception returned by __cxa_current_primary_exception().  This

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -121,7 +121,7 @@ static inline _Unwind_Reason_Code continueUnwinding(struct _Unwind_Exception *ex
 }
 
 
-extern "C" void __cxa_free_exception(void *thrown_exception) throw();
+extern "C" void __cxa_free_exception(void *thrown_exception) _LIBCXXRT_NOEXCEPT;
 extern "C" void __cxa_free_dependent_exception(void *thrown_exception);
 extern "C" void* __dynamic_cast(const void *sub,
                                 const __class_type_info *src,
@@ -241,8 +241,8 @@ namespace std
 	class exception
 	{
 		public:
-			virtual ~exception() throw();
-			virtual const char* what() const throw();
+			virtual ~exception() _LIBCXXRT_NOEXCEPT;
+			virtual const char* what() const _LIBCXXRT_NOEXCEPT;
 	};
 
 }
@@ -611,7 +611,7 @@ static void free_exception(char *e)
  * emergency buffer if malloc() fails, and may block if there are no such
  * buffers available.
  */
-extern "C" void *__cxa_allocate_exception(size_t thrown_size) throw()
+extern "C" void *__cxa_allocate_exception(size_t thrown_size) _LIBCXXRT_NOEXCEPT
 {
 	size_t size = thrown_size + sizeof(__cxa_exception);
 	char *buffer = alloc_or_die(size);
@@ -633,7 +633,7 @@ extern "C" void *__cxa_allocate_dependent_exception(void)
  * In this implementation, it is also called by __cxa_end_catch() and during
  * thread cleanup.
  */
-extern "C" void __cxa_free_exception(void *thrown_exception) throw()
+extern "C" void __cxa_free_exception(void *thrown_exception) _LIBCXXRT_NOEXCEPT
 {
 	__cxa_exception *ex = reinterpret_cast<__cxa_exception*>(thrown_exception) - 1;
 	// Free the object that was thrown, calling its destructor
@@ -712,7 +712,7 @@ static _Unwind_Reason_Code trace(struct _Unwind_Context *context, void *c)
  * a handler, prints a back trace before aborting.
  */
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
-extern "C" void *__cxa_begin_catch(void *e) throw();
+extern "C" void *__cxa_begin_catch(void *e) _LIBCXXRT_NOEXCEPT;
 #else
 extern "C" void *__cxa_begin_catch(void *e);
 #endif
@@ -792,7 +792,7 @@ static void throw_exception(__cxa_exception *ex)
 }
 
 extern "C" __cxa_exception *__cxa_init_primary_exception(
-		void *object, std::type_info* tinfo, void (*dest)(void *)) throw() {
+		void *object, std::type_info* tinfo, void (*dest)(void *)) _LIBCXXRT_NOEXCEPT {
 	__cxa_exception *ex = reinterpret_cast<__cxa_exception*>(object) - 1;
 
 	ex->referenceCount = 0;
@@ -1243,7 +1243,7 @@ BEGIN_PERSONALITY_FUNCTION(__gxx_personality_v0)
  * C++ exceptions) of the unadjusted pointer (for foreign exceptions).
  */
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
-extern "C" void *__cxa_begin_catch(void *e) throw()
+extern "C" void *__cxa_begin_catch(void *e) _LIBCXXRT_NOEXCEPT
 #else
 extern "C" void *__cxa_begin_catch(void *e)
 #endif
@@ -1452,14 +1452,14 @@ namespace pathscale
 	/**
 	 * Sets whether unexpected and terminate handlers should be thread-local.
 	 */
-	void set_use_thread_local_handlers(bool flag) throw()
+	void set_use_thread_local_handlers(bool flag) _LIBCXXRT_NOEXCEPT
 	{
 		thread_local_handlers = flag;
 	}
 	/**
 	 * Sets a thread-local unexpected handler.  
 	 */
-	unexpected_handler set_unexpected(unexpected_handler f) throw()
+	unexpected_handler set_unexpected(unexpected_handler f) _LIBCXXRT_NOEXCEPT
 	{
 		static __cxa_thread_info *info = thread_info();
 		unexpected_handler old = info->unexpectedHandler;
@@ -1469,7 +1469,7 @@ namespace pathscale
 	/**
 	 * Sets a thread-local terminate handler.  
 	 */
-	terminate_handler set_terminate(terminate_handler f) throw()
+	terminate_handler set_terminate(terminate_handler f) _LIBCXXRT_NOEXCEPT
 	{
 		static __cxa_thread_info *info = thread_info();
 		terminate_handler old = info->terminateHandler;
@@ -1484,7 +1484,7 @@ namespace std
 	 * Sets the function that will be called when an exception specification is
 	 * violated.
 	 */
-	unexpected_handler set_unexpected(unexpected_handler f) throw()
+	unexpected_handler set_unexpected(unexpected_handler f) _LIBCXXRT_NOEXCEPT
 	{
 		if (thread_local_handlers) { return pathscale::set_unexpected(f); }
 
@@ -1493,7 +1493,7 @@ namespace std
 	/**
 	 * Sets the function that is called to terminate the program.
 	 */
-	terminate_handler set_terminate(terminate_handler f) throw()
+	terminate_handler set_terminate(terminate_handler f) _LIBCXXRT_NOEXCEPT
 	{
 		if (thread_local_handlers) { return pathscale::set_terminate(f); }
 
@@ -1536,7 +1536,7 @@ namespace std
 	 * Returns whether there are any exceptions currently being thrown that
 	 * have not been caught.  This can occur inside a nested catch statement.
 	 */
-	bool uncaught_exception() throw()
+	bool uncaught_exception() _LIBCXXRT_NOEXCEPT
 	{
 		__cxa_thread_info *info = thread_info();
 		return info->globals.uncaughtExceptions != 0;
@@ -1545,7 +1545,7 @@ namespace std
 	 * Returns the number of exceptions currently being thrown that have not
 	 * been caught.  This can occur inside a nested catch statement.
 	 */
-	int uncaught_exceptions() throw()
+	int uncaught_exceptions() _LIBCXXRT_NOEXCEPT
 	{
 		__cxa_thread_info *info = thread_info();
 		return info->globals.uncaughtExceptions;
@@ -1553,7 +1553,7 @@ namespace std
 	/**
 	 * Returns the current unexpected handler.
 	 */
-	unexpected_handler get_unexpected() throw()
+	unexpected_handler get_unexpected() _LIBCXXRT_NOEXCEPT
 	{
 		__cxa_thread_info *info = thread_info();
 		if (info->unexpectedHandler)
@@ -1565,7 +1565,7 @@ namespace std
 	/**
 	 * Returns the current terminate handler.
 	 */
-	terminate_handler get_terminate() throw()
+	terminate_handler get_terminate() _LIBCXXRT_NOEXCEPT
 	{
 		__cxa_thread_info *info = thread_info();
 		if (info->terminateHandler)

--- a/src/memory.cc
+++ b/src/memory.cc
@@ -73,10 +73,8 @@ namespace std
 
 
 #if __cplusplus < 201103L
-#define NOEXCEPT throw()
 #define BADALLOC throw(std::bad_alloc)
 #else
-#define NOEXCEPT noexcept
 #define BADALLOC
 #endif
 
@@ -138,14 +136,14 @@ void* operator new(size_t size) BADALLOC
 
 
 __attribute__((weak))
-void* operator new(size_t size, const std::nothrow_t &) NOEXCEPT
+void* operator new(size_t size, const std::nothrow_t &) _LIBCXXRT_NOEXCEPT
 {
 	return noexcept_new<(::operator new)>(size);
 }
 
 
 __attribute__((weak))
-void operator delete(void * ptr) NOEXCEPT
+void operator delete(void * ptr) _LIBCXXRT_NOEXCEPT
 {
 	free(ptr);
 }
@@ -159,14 +157,14 @@ void * operator new[](size_t size) BADALLOC
 
 
 __attribute__((weak))
-void * operator new[](size_t size, const std::nothrow_t &) NOEXCEPT
+void * operator new[](size_t size, const std::nothrow_t &) _LIBCXXRT_NOEXCEPT
 {
 	return noexcept_new<(::operator new[])>(size);
 }
 
 
 __attribute__((weak))
-void operator delete[](void * ptr) NOEXCEPT
+void operator delete[](void * ptr) _LIBCXXRT_NOEXCEPT
 {
 	::operator delete(ptr);
 }
@@ -176,14 +174,14 @@ void operator delete[](void * ptr) NOEXCEPT
 #if __cplusplus >= 201402L
 
 __attribute__((weak))
-void operator delete(void * ptr, size_t) NOEXCEPT
+void operator delete(void * ptr, size_t) _LIBCXXRT_NOEXCEPT
 {
 	::operator delete(ptr);
 }
 
 
 __attribute__((weak))
-void operator delete[](void * ptr, size_t) NOEXCEPT
+void operator delete[](void * ptr, size_t) _LIBCXXRT_NOEXCEPT
 {
 	::operator delete(ptr);
 }

--- a/src/noexception.cc
+++ b/src/noexception.cc
@@ -30,7 +30,7 @@ namespace std
 	 * Returns whether there are any exceptions currently being thrown that
 	 * have not been caught. Without exception support this is always false.
 	 */
-	bool uncaught_exception() throw()
+	bool uncaught_exception() _LIBCXXRT_NOEXCEPT
 	{
 		return false;
 	}
@@ -38,7 +38,7 @@ namespace std
 	 * Returns the number of exceptions currently being thrown that have not
 	 * been caught. Without exception support this is always 0.
 	 */
-	int uncaught_exceptions() throw()
+	int uncaught_exceptions() _LIBCXXRT_NOEXCEPT
 	{
 		return 0;
 	}

--- a/src/stdexcept.cc
+++ b/src/stdexcept.cc
@@ -31,66 +31,66 @@
 
 namespace std {
 
-exception::exception() throw() {}
+exception::exception() _LIBCXXRT_NOEXCEPT {}
 exception::~exception() {}
-exception::exception(const exception&) throw() {}
-exception& exception::operator=(const exception&) throw()
+exception::exception(const exception&) _LIBCXXRT_NOEXCEPT {}
+exception& exception::operator=(const exception&) _LIBCXXRT_NOEXCEPT
 {
 	return *this;
 }
-const char* exception::what() const throw()
+const char* exception::what() const _LIBCXXRT_NOEXCEPT
 {
 	return "std::exception";
 }
 
-bad_alloc::bad_alloc() throw() {}
+bad_alloc::bad_alloc() _LIBCXXRT_NOEXCEPT {}
 bad_alloc::~bad_alloc() {}
-bad_alloc::bad_alloc(const bad_alloc&) throw() {}
-bad_alloc& bad_alloc::operator=(const bad_alloc&) throw()
+bad_alloc::bad_alloc(const bad_alloc&) _LIBCXXRT_NOEXCEPT {}
+bad_alloc& bad_alloc::operator=(const bad_alloc&) _LIBCXXRT_NOEXCEPT
 {
 	return *this;
 }
-const char* bad_alloc::what() const throw()
+const char* bad_alloc::what() const _LIBCXXRT_NOEXCEPT
 {
 	return "cxxrt::bad_alloc";
 }
 
 
 
-bad_cast::bad_cast() throw() {}
+bad_cast::bad_cast() _LIBCXXRT_NOEXCEPT {}
 bad_cast::~bad_cast() {}
-bad_cast::bad_cast(const bad_cast&) throw() {}
-bad_cast& bad_cast::operator=(const bad_cast&) throw()
+bad_cast::bad_cast(const bad_cast&) _LIBCXXRT_NOEXCEPT {}
+bad_cast& bad_cast::operator=(const bad_cast&) _LIBCXXRT_NOEXCEPT
 {
 	return *this;
 }
-const char* bad_cast::what() const throw()
+const char* bad_cast::what() const _LIBCXXRT_NOEXCEPT
 {
 	return "std::bad_cast";
 }
 
-bad_typeid::bad_typeid() throw() {}
+bad_typeid::bad_typeid() _LIBCXXRT_NOEXCEPT {}
 bad_typeid::~bad_typeid() {}
-bad_typeid::bad_typeid(const bad_typeid &__rhs) throw() {}
-bad_typeid& bad_typeid::operator=(const bad_typeid &__rhs) throw()
+bad_typeid::bad_typeid(const bad_typeid &__rhs) _LIBCXXRT_NOEXCEPT {}
+bad_typeid& bad_typeid::operator=(const bad_typeid &__rhs) _LIBCXXRT_NOEXCEPT
 {
 	return *this;
 }
 
-const char* bad_typeid::what() const throw()
+const char* bad_typeid::what() const _LIBCXXRT_NOEXCEPT
 {
 	return "std::bad_typeid";
 }
 
-bad_array_new_length::bad_array_new_length() throw() {}
+bad_array_new_length::bad_array_new_length() _LIBCXXRT_NOEXCEPT {}
 bad_array_new_length::~bad_array_new_length() {}
-bad_array_new_length::bad_array_new_length(const bad_array_new_length&) throw() {}
-bad_array_new_length& bad_array_new_length::operator=(const bad_array_new_length&) throw()
+bad_array_new_length::bad_array_new_length(const bad_array_new_length&) _LIBCXXRT_NOEXCEPT {}
+bad_array_new_length& bad_array_new_length::operator=(const bad_array_new_length&) _LIBCXXRT_NOEXCEPT
 {
 	return *this;
 }
 
-const char* bad_array_new_length::what() const throw()
+const char* bad_array_new_length::what() const _LIBCXXRT_NOEXCEPT
 {
 	return "std::bad_array_new_length";
 }

--- a/src/stdexcept.h
+++ b/src/stdexcept.h
@@ -29,17 +29,19 @@
  * of the exceptions for the runtime to use.  
  */
 
+#include "cxxabi.h"
+
 namespace std
 {
 
 	class exception
 	{
 	public:
-		exception() throw();
-		exception(const exception&) throw();
-		exception& operator=(const exception&) throw();
+		exception() _LIBCXXRT_NOEXCEPT;
+		exception(const exception&) _LIBCXXRT_NOEXCEPT;
+		exception& operator=(const exception&) _LIBCXXRT_NOEXCEPT;
 		virtual ~exception();
-		virtual const char* what() const throw();
+		virtual const char* what() const _LIBCXXRT_NOEXCEPT;
 	};
 
 
@@ -49,11 +51,11 @@ namespace std
 	class bad_alloc: public exception
 	{
 	public:
-		bad_alloc() throw();
-		bad_alloc(const bad_alloc&) throw();
-		bad_alloc& operator=(const bad_alloc&) throw();
+		bad_alloc() _LIBCXXRT_NOEXCEPT;
+		bad_alloc(const bad_alloc&) _LIBCXXRT_NOEXCEPT;
+		bad_alloc& operator=(const bad_alloc&) _LIBCXXRT_NOEXCEPT;
 		~bad_alloc();
-		virtual const char* what() const throw();
+		virtual const char* what() const _LIBCXXRT_NOEXCEPT;
 	};
 
 	/**
@@ -61,11 +63,11 @@ namespace std
 	 */
 	class bad_cast: public exception {
 	public:
-		bad_cast() throw();
-		bad_cast(const bad_cast&) throw();
-		bad_cast& operator=(const bad_cast&) throw();
+		bad_cast() _LIBCXXRT_NOEXCEPT;
+		bad_cast(const bad_cast&) _LIBCXXRT_NOEXCEPT;
+		bad_cast& operator=(const bad_cast&) _LIBCXXRT_NOEXCEPT;
 		virtual ~bad_cast();
-		virtual const char* what() const throw();
+		virtual const char* what() const _LIBCXXRT_NOEXCEPT;
 	};
 
 	/**
@@ -74,21 +76,21 @@ namespace std
 	class bad_typeid: public exception
 	{
 	public:
-		bad_typeid() throw();
-		bad_typeid(const bad_typeid &__rhs) throw();
+		bad_typeid() _LIBCXXRT_NOEXCEPT;
+		bad_typeid(const bad_typeid &__rhs) _LIBCXXRT_NOEXCEPT;
 		virtual ~bad_typeid();
-		bad_typeid& operator=(const bad_typeid &__rhs) throw();
-		virtual const char* what() const throw();
+		bad_typeid& operator=(const bad_typeid &__rhs) _LIBCXXRT_NOEXCEPT;
+		virtual const char* what() const _LIBCXXRT_NOEXCEPT;
 	};
 
 	class bad_array_new_length: public bad_alloc
 	{
 	public:
-		bad_array_new_length() throw();
-		bad_array_new_length(const bad_array_new_length&) throw();
-		bad_array_new_length& operator=(const bad_array_new_length&) throw();
+		bad_array_new_length() _LIBCXXRT_NOEXCEPT;
+		bad_array_new_length(const bad_array_new_length&) _LIBCXXRT_NOEXCEPT;
+		bad_array_new_length& operator=(const bad_array_new_length&) _LIBCXXRT_NOEXCEPT;
 		virtual ~bad_array_new_length();
-		virtual const char *what() const throw();
+		virtual const char *what() const _LIBCXXRT_NOEXCEPT;
 	};
 
 

--- a/test/test_exception.cc
+++ b/test/test_exception.cc
@@ -1,5 +1,5 @@
 #include "test.h"
-#include "unwind.h"
+#include "cxxabi.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/test/test_exception.cc
+++ b/test/test_exception.cc
@@ -1,5 +1,5 @@
 #include "test.h"
-#include "cxxabi.h"
+#include "unwind.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -7,6 +7,12 @@
 #include <exception>
 
 #define fprintf(...)
+
+#if __cplusplus < 201103L
+#define THROW(...) throw(__VA_ARGS__)
+#else
+#define THROW(...)
+#endif
 
 void log_cleanup(void* ignored)
 {
@@ -75,7 +81,7 @@ int inner(int i)
 	return -1;
 }
 
-int outer(int i) throw(float, int, foo, non_pod)
+int outer(int i) THROW(float, int, foo, non_pod)
 {
 	//CLEANUP
 	inner(i);

--- a/test/test_foreign_exceptions.cc
+++ b/test/test_foreign_exceptions.cc
@@ -21,7 +21,7 @@ extern "C" _Unwind_Reason_Code __wrap__Unwind_RaiseException (_Unwind_Exception 
 	// clobber exception class forcing libcxx own exceptions to be treated
 	// as foreign exception within libcxx itself
 	e->exception_class = EXCEPTION_CLASS('F','O','R','E','I','G','N','\0');
-	__real__Unwind_RaiseException(e);
+	return __real__Unwind_RaiseException(e);
 }
 
 _Unwind_Exception global_e;

--- a/test/test_guard.cc
+++ b/test/test_guard.cc
@@ -27,6 +27,7 @@ thread_local bool mainThread = false;
 void *init_static_race(void*);
 
 static int instances = 0; 
+static pthread_t thr;
 struct static_slow_struct
 {
 	int field;
@@ -34,7 +35,6 @@ struct static_slow_struct
 	{
 		if (mainThread)
 		{
-			pthread_t thr;
 			// See if another thread can make progress while we hold the lock.
 			// This will happen if we get the lock and init bytes the wrong way
 			// around.
@@ -61,5 +61,6 @@ void test_guards(void)
 	TEST(static_count == 2, "Each static only initialized once");
 	mainThread = true;
 	init_static_race(nullptr);
+	pthread_join(thr, nullptr);
 	TEST(instances == 1, "Two threads both tried to initialise a static");
 }

--- a/test/test_init_primary_exception.cc
+++ b/test/test_init_primary_exception.cc
@@ -10,14 +10,14 @@ extern "C"
 {
 	struct __cxa_exception;
 
-	void __cxa_free_exception(void *thrown_exception) throw();
-	void *__cxa_allocate_exception(size_t thrown_size) throw();
+	void __cxa_free_exception(void *thrown_exception) _LIBCXXRT_NOEXCEPT;
+	void *__cxa_allocate_exception(size_t thrown_size) _LIBCXXRT_NOEXCEPT;
 
 	void __cxa_increment_exception_refcount(void* thrown_exception);
 	void __cxa_decrement_exception_refcount(void* thrown_exception);
 
 	__cxa_exception *__cxa_init_primary_exception(
-		void *object, std::type_info* tinfo, void (*dest)(void *)) throw();
+		void *object, std::type_info* tinfo, void (*dest)(void *)) _LIBCXXRT_NOEXCEPT;
 
 	void __cxa_rethrow_primary_exception(void* thrown_exception);
 	void *__cxa_current_primary_exception();

--- a/test/test_init_primary_exception.cc
+++ b/test/test_init_primary_exception.cc
@@ -5,19 +5,33 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#if __cplusplus < 201103L
+#define NOEXCEPT throw()
+#else
+#define NOEXCEPT noexcept
+#endif
+
+#ifdef __GLIBCXX__
+// libstdc++ uses a different cxa_exception struct for refcounting, and returns
+// that from __cxa_init_primary_exception.
+#define CXA_EXCEPTION __cxa_refcounted_exception
+#else
+#define CXA_EXCEPTION __cxa_exception
+#endif
+
 namespace __cxxabiv1 {
 extern "C"
 {
-	struct __cxa_exception;
+	struct CXA_EXCEPTION;
 
-	void __cxa_free_exception(void *thrown_exception) _LIBCXXRT_NOEXCEPT;
-	void *__cxa_allocate_exception(size_t thrown_size) _LIBCXXRT_NOEXCEPT;
+	void __cxa_free_exception(void *thrown_exception) NOEXCEPT;
+	void *__cxa_allocate_exception(size_t thrown_size) NOEXCEPT;
 
 	void __cxa_increment_exception_refcount(void* thrown_exception);
 	void __cxa_decrement_exception_refcount(void* thrown_exception);
 
-	__cxa_exception *__cxa_init_primary_exception(
-		void *object, std::type_info* tinfo, void (*dest)(void *)) _LIBCXXRT_NOEXCEPT;
+	CXA_EXCEPTION *__cxa_init_primary_exception(
+		void *object, std::type_info* tinfo, void (*dest)(void *)) NOEXCEPT;
 
 	void __cxa_rethrow_primary_exception(void* thrown_exception);
 	void *__cxa_current_primary_exception();


### PR DESCRIPTION
This replaces usages of throw() with noexcept after C++11, since C++11 deprecates throw(), and C++17 even removes it.
