### PR TITLE
Add a simple implementation of __cxa_call_terminate

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,11 +1,11 @@
 libcxxrt_freebsd_task:
   matrix:
   - freebsd_instance:
-     image_family: freebsd-13-2
+     image_family: freebsd-13-3
   - freebsd_instance:
      image_family: freebsd-15-0-snap
   - freebsd_instance:
-     image_family: freebsd-14-0
+     image_family: freebsd-14-1
 
   install_script: uname -a && pkg install -y cmake ninja
 

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -1432,6 +1432,19 @@ extern "C" void __cxa_call_unexpected(void*exception)
 }
 
 /**
+ * ABI function, called when an object destructor exits due to an
+ * exception during stack unwinding.
+ *
+ * This function does not return.
+ */
+extern "C" void __cxa_call_terminate(void*exception) _LIBCXXRT_NOEXCEPT
+{
+	std::terminate();
+	// Should not be reached.
+	abort();
+}
+
+/**
  * ABI function, returns the adjusted pointer to the exception object.
  */
 extern "C" void *__cxa_get_exception_ptr(void *exceptionObject)


### PR DESCRIPTION
This function is called by GCC 14 if a destructor invoked during exception unwinding throws an exception.