### PR TITLE
Don't partially disable exception spec tests, test up to C++17

### DIFF
--- a/test/test_exception.cc
+++ b/test/test_exception.cc
@@ -9,6 +9,10 @@
 #define fprintf(...)
 
 #if __cplusplus < 201103L
+#define LIBCXXRT_TEST_EXCEPTION_SPEC
+#endif
+
+#ifdef LIBCXXRT_TEST_EXCEPTION_SPEC
 #define THROW(...) throw(__VA_ARGS__)
 #else
 #define THROW(...)
@@ -344,7 +348,9 @@ void test_exceptions(void)
 		TEST(violations == 1, "Exactly one exception spec violation");
 	}
 	catch (int64_t i) {
+#ifdef LIBCXXRT_TEST_EXCEPTION_SPEC
 		TEST(0, "Caught int64_t, but that violates an exception spec");
+#endif
 	}
 	int a;
 	try {

--- a/test/test_exception.cc
+++ b/test/test_exception.cc
@@ -8,7 +8,7 @@
 
 #define fprintf(...)
 
-#if __cplusplus < 201103L
+#if __cplusplus < 201703L
 #define LIBCXXRT_TEST_EXCEPTION_SPEC
 #endif
 


### PR DESCRIPTION
Currently the test for exception spec violation is still run for C++11
or newer despite the fact that we omit the exception spec for these
C++ versions. This test of course fails, since there is no exception
spec that could be violated.

Also, test exception specs up to C++17. Exception specs were deprecated in C++11 but not removed until C++17.

References: https://github.com/libcxxrt/libcxxrt/issues/42