### PR TITLE
Disable system output comparison test for FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,12 +14,14 @@ libcxxrt_freebsd_task:
       configure_script: |
         mkdir Build
         cd Build
-        cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++  -DBUILD_TESTS=ON
+        cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+            -DBUILD_TESTS=ON -DCOMPARE_TEST_OUTPUT_TO_SYSTEM_OUTPUT=OFF
     - name: Configure (Release)
       configure_script: |
         mkdir Build
         cd Build
-        cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++  -DBUILD_TESTS=ON
+        cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+            -DBUILD_TESTS=ON -DCOMPARE_TEST_OUTPUT_TO_SYSTEM_OUTPUT=OFF
 
   build_script: cd Build && NINJA_STATUS="%p [%f:%s/%t] %o/s, %es" ninja
 


### PR DESCRIPTION
The test suite provides the option to compare test results against the system C++ ABI implementation. On FreeBSD this comparison is of questionable value, as the system C++ ABI implementation is libcxxrt.

Furthermore, this comparison can give false negatives due to a race in test_guard.cc causing an off-by-one in number of tests run against the system and libcxxrt implementations. Since the comparison is implemented as a diff(1) of the output, this difference in the number of tests run causes spurious failures.

Closes:		https://github.com/libcxxrt/libcxxrt/issues/42
Sponsored by:	The FreeBSD Foundation